### PR TITLE
fix: changed options source and updated tsc-alias dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 const tscAlias = require('tsc-alias');
 
-module.exports = function() {
-    return {
-      name: 'tscAlias',
-      async writeBundle(options) {
-        return tscAlias.replaceTscAliasPaths(options);
-      }
-    }
-  }
-  
+module.exports = function (options) {
+  return {
+    name: 'tscAlias',
+    async writeBundle() {
+      return tscAlias.replaceTscAliasPaths(options);
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-tsc-alias",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Replace alias paths with relative paths after typescript compilation during rollup bundling (tsc-alias)",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   ],
   "homepage": "https://github.com/valentiniljaz/rollup-plugin-tsc-alias#readme",
   "dependencies": {
-    "tsc-alias": "^1.6.4"
+    "tsc-alias": "^1.8.10"
   },
   "peerDependencies": {
     "rollup": "> 2.0"


### PR DESCRIPTION
This pull request includes changes to enhance the functionality and update dependencies of the `rollup-plugin-tsc-alias` package. The most important changes include adding an `options` parameter to the `writeBundle` function and updating the `tsc-alias` dependency version.

Enhancements to functionality:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L3-R10): Modified the `writeBundle` function to accept an `options` parameter, allowing for more flexible usage of the `tscAlias.replaceTscAliasPaths` method.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R30): Updated the `tsc-alias` dependency version from `^1.6.4` to `^1.8.10`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the package version from `1.1.2` to `1.1.3`.